### PR TITLE
Add AI email assistant project structure

### DIFF
--- a/ai-email-assistant/.gitignore
+++ b/ai-email-assistant/.gitignore
@@ -1,0 +1,12 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Virtual environment
+venv/
+
+# Node modules
+node_modules/
+
+# Environment variables
+.env

--- a/ai-email-assistant/README.md
+++ b/ai-email-assistant/README.md
@@ -1,0 +1,3 @@
+# AI Email Assistant
+
+This project combines a FastAPI backend with a React frontend to summarize and reply to emails using AI.

--- a/ai-email-assistant/backend/ai_utils.py
+++ b/ai-email-assistant/backend/ai_utils.py
@@ -1,0 +1,12 @@
+"""LLM-powered summarization and reply generation."""
+
+
+def summarize_email(content):
+    """Return a summary for the given email content."""
+    pass
+
+
+def generate_reply(summary):
+    """Generate a reply based on the summary."""
+    pass
+

--- a/ai-email-assistant/backend/app.py
+++ b/ai-email-assistant/backend/app.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get('/')
+def read_root():
+    return {"message": "AI Email Assistant backend"}
+

--- a/ai-email-assistant/backend/auth.py
+++ b/ai-email-assistant/backend/auth.py
@@ -1,0 +1,7 @@
+"""OAuth2 setup for email services."""
+
+
+def get_credentials():
+    """Return OAuth2 credentials for accessing email services."""
+    pass
+

--- a/ai-email-assistant/backend/email_utils.py
+++ b/ai-email-assistant/backend/email_utils.py
@@ -1,0 +1,12 @@
+"""Utility functions for fetching and sending emails."""
+
+
+def fetch_emails(service):
+    """Fetch emails from the given service (Gmail/Outlook)."""
+    pass
+
+
+def send_email(service, message):
+    """Send an email using the given service."""
+    pass
+

--- a/ai-email-assistant/backend/requirements.txt
+++ b/ai-email-assistant/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/ai-email-assistant/docker-compose.yml
+++ b/ai-email-assistant/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  backend:
+    build: ./backend
+    ports:
+      - "8000:8000"
+  frontend:
+    build: ./frontend
+    ports:
+      - "3000:3000"

--- a/ai-email-assistant/frontend/package.json
+++ b/ai-email-assistant/frontend/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "ai-email-assistant-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.0.0"
+  }
+}

--- a/ai-email-assistant/frontend/src/App.js
+++ b/ai-email-assistant/frontend/src/App.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function App() {
+  return (
+    <div className="App">
+      <h1>AI Email Assistant</h1>
+    </div>
+  );
+}
+
+export default App;

--- a/ai-email-assistant/frontend/src/components/Placeholder.js
+++ b/ai-email-assistant/frontend/src/components/Placeholder.js
@@ -1,0 +1,1 @@
+// Placeholder component

--- a/ai-email-assistant/frontend/src/index.js
+++ b/ai-email-assistant/frontend/src/index.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/ai-email-assistant/frontend/src/pages/Placeholder.js
+++ b/ai-email-assistant/frontend/src/pages/Placeholder.js
@@ -1,0 +1,1 @@
+// Placeholder page

--- a/ai-email-assistant/frontend/tailwind.config.js
+++ b/ai-email-assistant/frontend/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- scaffold `ai-email-assistant` project
- add backend FastAPI stub
- add frontend React skeleton with Tailwind config
- include example Docker Compose and `.gitignore`

## Testing
- `pytest -q`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854ae22f5e8832ea0159d0a4cadc1ab